### PR TITLE
Change source url to follow sourceforge redirect

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -35,8 +35,8 @@ cd $BUILD_DIR
 
 # download
 echo "-----> Downloading"
-ZBAR_URL="http://freefr.dl.sourceforge.net/project/zbar/zbar/0.10/zbar-0.10.tar.bz2"
-curl $ZBAR_URL -s -o - | tar jxf - -C $BUILD_DIR
+ZBAR_URL="https://sourceforge.net/projects/zbar/files/zbar/0.10/zbar-0.10.tar.bz2/download"
+curl -L $ZBAR_URL -s -o - | tar jxf - -C $BUILD_DIR
 
 cd zbar-0.10
 


### PR DESCRIPTION
Instead of linking directly to the mirror. Related to #5 

@joshRpowell I was unable to get it working with the github mirror, it looks like the source files are different. I was, however, able to get it working by following the sourceforge redirect to the mirror instead of just directly linking to it. It might take a few extra seconds to start the download, but it should not break later on. Can you test it and see if it's working for your use case?

This is how I was able to test it:
`heroku buildpacks:remove https://github.com/sheck/heroku-buildpack-zbar`
`heroku buildpacks:add --index 1 https://github.com/sheck/heroku-buildpack-zbar\#new-source-url`