### PR TITLE
Fixes "bzip2: (stdin) is not a bzip2 file." error when attempting to download buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ cd $BUILD_DIR
 
 # download
 echo "-----> Downloading"
-ZBAR_URL="https://sourceforge.net/projects/zbar/files/zbar/0.10/zbar-0.10.tar.bz2/download"
+ZBAR_URL="https://freefr.dl.sourceforge.net/project/zbar/zbar/0.10/zbar-0.10.tar.bz2"
 curl -L $ZBAR_URL -s -o - | tar jxf - -C $BUILD_DIR
 
 cd zbar-0.10

--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ cd $BUILD_DIR
 
 # download
 echo "-----> Downloading"
-ZBAR_URL="https://freefr.dl.sourceforge.net/project/zbar/zbar/0.10/zbar-0.10.tar.bz2"
+ZBAR_URL="https://github.com/ZBar/ZBar/archive/0.10.tar.gz"
 curl -L $ZBAR_URL -s -o - | tar jxf - -C $BUILD_DIR
 
 cd zbar-0.10


### PR DESCRIPTION
* Same old bug is back! https://github.com/sheck/heroku-buildpack-zbar/issues/2

```
-----> Fetching set buildpack https://github.com/sheck/heroku-buildpack-zbar... done
-----> ZBAR app detected
-----> Downloading
bzip2: (stdin) is not a bzip2 file.
tar: Child returned status 2
tar: Error is not recoverable: exiting now
 !     Push rejected, failed to compile ZBAR app
 ```

Not sure if `https://sourceforge.net/projects/zbar/files/zbar/0.10/zbar-0.10.tar.bz2/download` has changed somehow.