### PR TITLE
Use GitHub mirror

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -38,7 +38,7 @@ echo "-----> Downloading"
 ZBAR_URL="https://github.com/sheck/ZBar/archive/0.10-sourceforge.tar.gz"
 curl -L $ZBAR_URL -s | tar zx -C $BUILD_DIR
 
-cd ZBar-0.10
+cd ZBar-0.10-sourceforge
 
 # patching
 echo "-----> Applying JPEG patch"

--- a/bin/compile
+++ b/bin/compile
@@ -35,10 +35,10 @@ cd $BUILD_DIR
 
 # download
 echo "-----> Downloading"
-ZBAR_URL="https://sourceforge.net/projects/zbar/files/zbar/0.10/zbar-0.10.tar.bz2/download"
-curl -L $ZBAR_URL -s -o - | tar jxf - -C $BUILD_DIR
+ZBAR_URL="https://github.com/ZBar/ZBar/archive/0.10.tar.gz"
+curl -L $ZBAR_URL -s | tar zx -C $BUILD_DIR
 
-cd zbar-0.10
+cd ZBar-0.10
 
 # patching
 echo "-----> Applying JPEG patch"

--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ cd $BUILD_DIR
 
 # download
 echo "-----> Downloading"
-ZBAR_URL="https://github.com/ZBar/ZBar/archive/0.10.tar.gz"
+ZBAR_URL="https://github.com/sheck/ZBar/archive/0.10-sourceforge.tar.gz"
 curl -L $ZBAR_URL -s | tar zx -C $BUILD_DIR
 
 cd ZBar-0.10


### PR DESCRIPTION
Related to #7 and #5, this PR changes the source file for the ZBar library used by the compilation script.

In #5 I looked into getting the GitHub mirror to work but was unsuccessful. I tried it again this time... and was unsuccessful! 😂 So, I ended up forking ZBar and using the files from SourceForge (somehow in the translation from Mercurial to Git, something was getting changed) and was able to get it working.

The benefit here is GitHub's files are much more reliable than SourceForge so this issue shouldn't pop up again. Also, later on I can just add the patch as a git commit, so we can skip that step entirely.

I verified that this branch of the build pack works with a personal app of mine. @joshRpowell and @vicmaster if either of you would like to check this with your own applications, please do — if not, I will merge this tomorrow afternoon.